### PR TITLE
Parse ColorValue and color-block added

### DIFF
--- a/website/scripts/sync-api-docs/generateMarkdown.js
+++ b/website/scripts/sync-api-docs/generateMarkdown.js
@@ -8,7 +8,7 @@
 const {
   formatPlatformName,
   formatDefaultPlatformProp,
-  formatTypePlatformProp,
+  formatMultiPlatformProp,
   maybeLinkifyType,
   maybeLinkifyTypeName,
 } = require('./propFormatter');
@@ -50,11 +50,16 @@ function generateProp(propName, prop) {
   // console.log(propName, prop);
   const infoTable = generateTable([
     {
-      Type: formatTypePlatformProp(prop, prop.rnTags.type),
+      Type:
+        prop.rnTags && prop.rnTags.type
+          ? formatMultiPlatformProp(propName, prop, prop.rnTags.type)
+          : maybeLinkifyType(prop.flowType),
       Required: prop.required ? 'Yes' : 'No',
-      Default: prop.defaultValue.value.includes('Platform.OS')
-        ? formatTypePlatformProp(prop, prop.rnTags.default)
-        : '`' + prop.defaultValue.value + '`',
+      Default: prop.defaultValue
+        ? prop.defaultValue.value.includes('Platform.OS')
+          ? formatMultiPlatformProp(propName, prop, prop.rnTags.default)
+          : '`' + prop.defaultValue.value + '`'
+        : '',
     },
   ]);
 

--- a/website/scripts/sync-api-docs/propFormatter.js
+++ b/website/scripts/sync-api-docs/propFormatter.js
@@ -17,6 +17,8 @@ function formatPlatformName(platform) {
       return '<div class="label ios">' + 'iOS' + '</div>';
     case 'android':
       return '<div class="label android">' + 'Android' + '</div>';
+    case 'tv':
+      return '<div class="label tv">' + 'TV' + '</div>';
   }
   return platform;
 }
@@ -30,10 +32,10 @@ function formatDefaultPlatformProp(defaultProps, propName) {
   return formattedProps;
 }
 
-// Generates rows for type prop
-function formatTypePlatformProp(prop, item) {
+// Generates rows for different platform dependent prop
+function formatMultiPlatformProp(propName, prop, item) {
   let tableRows = '';
-
+  // console.log(propName)
   if (prop.rnTags && item) {
     if (item.length) {
       item.forEach(tag => {
@@ -41,7 +43,11 @@ function formatTypePlatformProp(prop, item) {
         if (isMatch) {
           const platform = isMatch[0].match(/ [a-z]*/);
           tag = tag.replace(/{@platform [a-z]*}/g, '');
-          tag = tag + formatPlatformName(platform[0].trim());
+          const colorBlock =
+            propName === 'color' && prop.rnTags.default && !tag.includes('null')
+              ? '<ins style="background:' + tag + '" class="color-box"></ins>'
+              : '';
+          tag = tag + colorBlock + formatPlatformName(platform[0].trim());
         }
         tableRows = tableRows + tag + '<hr/>';
       });
@@ -97,7 +103,7 @@ function maybeLinkifyTypeName(name) {
 module.exports = {
   formatPlatformName,
   formatDefaultPlatformProp,
-  formatTypePlatformProp,
+  formatMultiPlatformProp,
   maybeLinkifyType,
   maybeLinkifyTypeName,
 };


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
Parsing ColorValue custom prop and color-block to show platform-dependent
![Screenshot 2020-07-08 at 2 39 27 AM](https://user-images.githubusercontent.com/31184591/86848411-9641a500-c0cb-11ea-8700-ec8859127872.png)
 colors added.