### PR TITLE
Fix lines, removed commas near markdown headings

### DIFF
--- a/docs/profile-hermes.md
+++ b/docs/profile-hermes.md
@@ -45,7 +45,7 @@ This allows React Native to build the bundle during its running process
 
 - In the `android/app/build.gradle` file of the React Native app that you use to test, add
 
-```sh
+```java
 project.ext.react = [
   bundleInDebug: true,
 ]
@@ -59,25 +59,26 @@ cd android && ./gradlew clean
 
 - Run your app as usual
 
-```jsx
+```sh
 npx react-native run-android
 ```
 
 ### Common errors encountered during the process
 
-- #### `adb: no devices/emulators found` or `adb: device offline`
+#### `adb: no devices/emulators found` or `adb: device offline`
 
-  - Cause: The CLI cannot access the device or emulator (through adb) you are using to run the app
-  - Solution: make sure your Android device/ emulator is connected and running. The command only works when it can access adb
+- Cause: The CLI cannot access the device or emulator (through adb) you are using to run the app
+- Solution: make sure your Android device/ emulator is connected and running. The command only works when it can access adb
 
-- #### `There is no file in the cache/ directory`
+#### `There is no file in the cache/ directory`
 
-  - Cause: cannot find any **.cpuprofile** file in your app's **cache/** directory. You might have forgotten to record a profile from the device
-  - Solution: instruction on how to enable/ disable profiler from device is [above](profile-hermes.md#recording-a-hermes-sampling-profile)
+- Cause: cannot find any **.cpuprofile** file in your app's **cache/** directory. You might have forgotten to record a profile from the device
+- Solution: instruction on how to enable/ disable profiler from device is [above](profile-hermes.md#recording-a-hermes-sampling-profile)
 
-- #### `Error: your_profile_name.cpuprofile is an empty file`
-  - Cause: the profile is empty, it might be because Hermes is not running correctly or crashes
-  - Solution: make sure your app is running with Hermes and update Hermes to the latest version
+#### `Error: your_profile_name.cpuprofile is an empty file`
+
+- Cause: the profile is empty, it might be because Hermes is not running correctly or crashes
+- Solution: make sure your app is running with Hermes and update Hermes to the latest version
 
 ## Open the downloaded profile on Chrome DevTools
 


### PR DESCRIPTION
# Summary 

This PR is to resolve a break-line issue in profile-hermes.md

## Screenshot

<img width="647" alt="90747702-8d9adc00-e2d1-11ea-82f5-f5f57fa20da6" src="https://user-images.githubusercontent.com/31125345/90764298-bfc63100-e305-11ea-868e-c7831b6b66bb.png">

The issue was caused due to `-` inserted before markdown headers. Upon removing those, the issue was resolved.